### PR TITLE
Add EC2 listing script

### DIFF
--- a/listar_ec2.py
+++ b/listar_ec2.py
@@ -1,0 +1,20 @@
+import boto3
+
+
+def listar_instancias():
+    ec2 = boto3.client("ec2")
+    regions = [region["RegionName"] for region in ec2.describe_regions()["Regions"]]
+
+    for region in regions:
+        regional_client = boto3.client("ec2", region_name=region)
+        reservations = regional_client.describe_instances()["Reservations"]
+        for reservation in reservations:
+            for instance in reservation.get("Instances", []):
+                instance_id = instance.get("InstanceId")
+                instance_type = instance.get("InstanceType")
+                state = instance.get("State", {}).get("Name")
+                print(f"ID da Instância: {instance_id}\nTipo: {instance_type}\nEstado: {state}\nRegião: {region}\n")
+
+
+if __name__ == "__main__":
+    listar_instancias()

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Este projeto em Python possui um script simples que utiliza a biblioteca `boto3`
 
 ## Uso
 
-O script `listar_ec2.py` (não incluído neste repositório de exemplo) se conecta à AWS e lista todas as instâncias EC2, exibindo os principais atributos.
+O script `listar_ec2.py` se conecta à AWS e lista todas as instâncias EC2, exibindo os principais atributos.
 
 Execute o script da seguinte forma:
 


### PR DESCRIPTION
## Summary
- add a Python script that lists EC2 instances across regions
- update README to mention the included script

## Testing
- `python listar_ec2.py` *(fails: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_683fa604ee40832a82a21f4b32286f79